### PR TITLE
Update config

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
     ],
     "implicit-arrow-linebreak": 0,
     quotes: ["error", "single", { avoidEscape: true }],
-    "prettier/prettier": ["error"],
+    "prettier/prettier": ["warn"],
     "import/prefer-default-export": "off",
     "import/no-default-export": "error",
     "import/order": [


### PR DESCRIPTION
Make `prettier/prettier` rule use `warn` instead of `error` so that local build doesn't fail if prettier isn't happy.

We're using pre-commit hooks with setup of not allowing even a single warning, so we should be good.