### PR TITLE
Update "no duplicate props" rule config

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ module.exports = {
     "global-require": 0,
     "react/jsx-wrap-multilines": 0,
     "react/require-default-props": 0,
+    "react/jsx-no-duplicate-props": [1, { ignoreCase: false }],
     "no-unused-vars": 0,
     // '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     "@typescript-eslint/camelcase": 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streetshares/eslint-config-streetshares",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Streetshares ESLint config",
   "main": "index.js",
   "repository": "https://github.com/streetshares/eslint-config-streetshares",


### PR DESCRIPTION
W/o the changes in this PR, eslint was treating `inputProps` and `InputProps` as the same prop which is incorrect as we can pass both to MUI `TextField`.